### PR TITLE
Added check for gta_remastered plugin

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -15,7 +15,7 @@ USE_PSPSDK_LIBC = 1
 USE_PSPSDK_LIBS = 1
 
 #LIBS = -lpspsystemctrl_kernel -lm
-LIBS = -lpspsystemctrl_user -lm -lpsprtc
+LIBS = -lpspexploit -lpspsystemctrl_user -lm -lpsprtc
 
 PSPSDK = $(shell psp-config --pspsdk-path)
 include $(PSPSDK)/lib/build_prx.mak

--- a/source/blitn.h
+++ b/source/blitn.h
@@ -19,6 +19,7 @@
 #ifndef __BLITN_H__
 #define __BLITN_H__
 
+#include <libpspexploit.h>
 
 #define SCREEN_WIDTH 480.0f
 #define SCREEN_HEIGHT 272.0f
@@ -66,21 +67,7 @@ u32 boxcol[MAX_BOXES];
 #define SIZE_VCS_SMALL 0.46f //0.5f
 #define SIZE_VCS_NORMAL 0.6f
 #define SIZE_VCS_BIG 0.8f 
-#define SIZE_VCS_HUGE 1.0f 
-
-
-#define MAKE_JUMP(a, f) _sw(0x08000000 | (((u32)(f) & 0x0FFFFFFC) >> 2), a);
-
-#define HIJACK_FUNCTION(a, f, ptr) { \
-  u32 _func_ = a; \
-  static u32 patch_buffer[3]; \
-  _sw(_lw(_func_), (u32)patch_buffer); \
-  _sw(_lw(_func_ + 4), (u32)patch_buffer + 8);\
-  MAKE_JUMP((u32)patch_buffer + 4, _func_ + 8); \
-  _sw(0x08000000 | (((u32)(f) >> 2) & 0x03FFFFFF), _func_); \
-  _sw(0, _func_ + 4); \
-  ptr = (void *)patch_buffer; \
-}
+#define SIZE_VCS_HUGE 1.0f
 
 
 /// box

--- a/source/cheats.c
+++ b/source/cheats.c
@@ -7987,7 +7987,7 @@ void *hover_vehicle(int calltype, int keypress, int defaultstatus) {
         setFloat(pcar + (LCS?0x88:0x78), -0.04 * xstick); // spin vehicle around Z world axis (slow turning -0.02 | -0.05 faster turning)
         
         ///manual hovering up/down
-        if( (current_buttons & PSP_CTRL_UP) && ((xyspeed < 0.1f) || (current_buttons & PSP_CTRL_RTRIGGER)) && flag_menu_running == 0 ) 
+        if( (current_buttons & PSP_CTRL_UP) && ((xyspeed < 0.1f) || (current_buttons & ((GTA_REMASTERED==2)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER))) && flag_menu_running == 0 ) 
           setFloat(pcar+(LCS?0x98:0x148), getFloat(pcar+(LCS?0x98:0x148)) + 0.02); // 0.015 for LCS?
         if( (current_buttons & PSP_CTRL_DOWN) && ((xyspeed < 0.1f) || (current_buttons & PSP_CTRL_RTRIGGER)) && flag_menu_running == 0 ) {
           setFloat(pcar+(LCS?0x98:0x148), getFloat(pcar+(LCS?0x98:0x148)) - 0.02);
@@ -8010,7 +8010,7 @@ void *hover_vehicle(int calltype, int keypress, int defaultstatus) {
       
         ///////////////////////////////////////////////////////////
 
-        if( !(current_buttons & PSP_CTRL_RTRIGGER) && flag_menu_running == 0 ) { /// "handbrake" keeps momentum (old style)
+        if( !(current_buttons & ((GTA_REMASTERED==2)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER)) && flag_menu_running == 0 ) { /// "handbrake" keeps momentum (old style)
           if( xyspeed > 0.1f ) { // to allow hover animation without force forward
             if( getVehicleCurrentGear(pcar) > 0 ) { // not in reverse
               /// keep the momentum in the direction the vehicle
@@ -8027,7 +8027,7 @@ void *hover_vehicle(int calltype, int keypress, int defaultstatus) {
         }
              
         /// thrust, reverse & automatically slowing down (could also be done by setting lower/higher speed but I'd like to keep the "handbrake feature")
-        if( current_buttons & PSP_CTRL_CROSS && flag_menu_running == 0 ) {  /// forward
+        if( current_buttons & ((GTA_REMASTERED!=2)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER) && flag_menu_running == 0 ) {  /// forward
           setFloat(pcar+(LCS?0x70:0x140), getFloat(pcar+(LCS?0x70:0x140)) + getFloat(pcar+0x10) * 0.010);
           setFloat(pcar+(LCS?0x74:0x144), getFloat(pcar+(LCS?0x74:0x144)) + getFloat(pcar+0x14) * 0.010);
           setFloat(pcar+(LCS?0x78:0x148), getFloat(pcar+(LCS?0x78:0x148)) + getFloat(pcar+0x18) * 0.022);

--- a/source/cheats.c
+++ b/source/cheats.c
@@ -7987,7 +7987,7 @@ void *hover_vehicle(int calltype, int keypress, int defaultstatus) {
         setFloat(pcar + (LCS?0x88:0x78), -0.04 * xstick); // spin vehicle around Z world axis (slow turning -0.02 | -0.05 faster turning)
         
         ///manual hovering up/down
-        if( (current_buttons & PSP_CTRL_UP) && ((xyspeed < 0.1f) || (current_buttons & ((GTA_REMASTERED==2)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER))) && flag_menu_running == 0 ) 
+        if( (current_buttons & PSP_CTRL_UP) && ((xyspeed < 0.1f) || (current_buttons & ((GTA_REMASTERED==1)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER))) && flag_menu_running == 0 ) 
           setFloat(pcar+(LCS?0x98:0x148), getFloat(pcar+(LCS?0x98:0x148)) + 0.02); // 0.015 for LCS?
         if( (current_buttons & PSP_CTRL_DOWN) && ((xyspeed < 0.1f) || (current_buttons & PSP_CTRL_RTRIGGER)) && flag_menu_running == 0 ) {
           setFloat(pcar+(LCS?0x98:0x148), getFloat(pcar+(LCS?0x98:0x148)) - 0.02);
@@ -8010,7 +8010,7 @@ void *hover_vehicle(int calltype, int keypress, int defaultstatus) {
       
         ///////////////////////////////////////////////////////////
 
-        if( !(current_buttons & ((GTA_REMASTERED==2)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER)) && flag_menu_running == 0 ) { /// "handbrake" keeps momentum (old style)
+        if( !(current_buttons & ((GTA_REMASTERED==1)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER)) && flag_menu_running == 0 ) { /// "handbrake" keeps momentum (old style)
           if( xyspeed > 0.1f ) { // to allow hover animation without force forward
             if( getVehicleCurrentGear(pcar) > 0 ) { // not in reverse
               /// keep the momentum in the direction the vehicle
@@ -8027,7 +8027,7 @@ void *hover_vehicle(int calltype, int keypress, int defaultstatus) {
         }
              
         /// thrust, reverse & automatically slowing down (could also be done by setting lower/higher speed but I'd like to keep the "handbrake feature")
-        if( current_buttons & ((GTA_REMASTERED!=2)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER) && flag_menu_running == 0 ) {  /// forward
+        if( current_buttons & ((GTA_REMASTERED!=1)?PSP_CTRL_CROSS:PSP_CTRL_RTRIGGER) && flag_menu_running == 0 ) {  /// forward
           setFloat(pcar+(LCS?0x70:0x140), getFloat(pcar+(LCS?0x70:0x140)) + getFloat(pcar+0x10) * 0.010);
           setFloat(pcar+(LCS?0x74:0x144), getFloat(pcar+(LCS?0x74:0x144)) + getFloat(pcar+0x14) * 0.010);
           setFloat(pcar+(LCS?0x78:0x148), getFloat(pcar+(LCS?0x78:0x148)) + getFloat(pcar+0x18) * 0.022);

--- a/source/cheats.h
+++ b/source/cheats.h
@@ -19,41 +19,10 @@
 #ifndef __CHEATS_H__
 #define __CHEATS_H__
 
+#include <libpspexploit.h>
 
 int PatchLCS(u32 addr, u32 text_addr);
 int PatchVCS(u32 addr, u32 text_addr);
-
-#define MAKE_CALL(a, f) _sw(0x0C000000 | (((u32)(f) >> 2) & 0x03FFFFFF), a);
-
-#define MAKE_JUMP(a, f) _sw(0x08000000 | (((u32)(f) & 0x0FFFFFFC) >> 2), a);
-
-#define HIJACK_FUNCTION(a, f, ptr) { \
-  u32 _func_ = a; \
-  static u32 patch_buffer[3]; \
-  _sw(_lw(_func_), (u32)patch_buffer); \
-  _sw(_lw(_func_ + 4), (u32)patch_buffer + 8);\
-  MAKE_JUMP((u32)patch_buffer + 4, _func_ + 8); \
-  _sw(0x08000000 | (((u32)(f) >> 2) & 0x03FFFFFF), _func_); \
-  _sw(0, _func_ + 4); \
-  ptr = (void *)patch_buffer; \
-}
-
-#define REDIRECT_FUNCTION(a, f) { \
-  u32 _func_ = a; \
-  _sw(0x08000000 | (((u32)(f) >> 2) & 0x03FFFFFF), _func_); \
-  _sw(0, _func_ + 4); \
-}
-
-#define MAKE_DUMMY_FUNCTION(a, r) { \
-  u32 _func_ = a; \
-  if (r == 0) { \
-    _sw(0x03E00008, _func_); \
-    _sw(0x00001021, _func_ + 4); \
-  } else { \
-    _sw(0x03E00008, _func_); \
-    _sw(0x24020000 | r, _func_ + 4); \
-  } \
-}
 
 
 typedef struct {

--- a/source/main.c
+++ b/source/main.c
@@ -28,6 +28,7 @@
 #include <math.h>
 #include <malloc.h>
 #include <pspsysmem.h>
+#include <libpspexploit.h>
 
 #include "main.h"
 #include "utils.h"
@@ -139,7 +140,7 @@ u32 mod_text_size;
 u32 mod_data_size;
 register int gp asm("gp");
 static STMOD_HANDLER previous;
-int ADRENALINE = 0, PPSSPP = 0, LCS = 0, VCS = 0;
+int ADRENALINE = 0, PPSSPP = 0, LCS = 0, VCS = 0, GTA_REMASTERED = 0;
 char buffer[256];
 #ifdef CONFIG
 char config[128];
@@ -6389,6 +6390,16 @@ int OnModuleStart(SceModule2 *mod) {
   char *modname = mod->modname;
   
   if( strcmp(modname, "GTA3") == 0 ) {
+
+    if (pspXploitFindFunction("GTARemastered", "GTARemasteredLib", 0x49346935) != 0){
+      if (pspXploitFindFunction("GTARemastered", "GTARemasteredLib", 0xF1396FCD) != 0){
+        GTA_REMASTERED = 1; // v1
+      }
+      else {
+        GTA_REMASTERED = 2; // v2
+      }
+    }
+
     mod_text_addr = mod->text_addr;
     mod_text_size = mod->text_size;
     mod_data_size = mod->data_size;

--- a/source/main.c
+++ b/source/main.c
@@ -6391,12 +6391,14 @@ int OnModuleStart(SceModule2 *mod) {
   
   if( strcmp(modname, "GTA3") == 0 ) {
 
-    if (pspXploitFindFunction("GTARemastered", "GTARemasteredLib", 0x49346935) != 0){
-      if (pspXploitFindFunction("GTARemastered", "GTARemasteredLib", 0xF1396FCD) != 0){
-        GTA_REMASTERED = 1; // v1
-      }
-      else {
-        GTA_REMASTERED = 2; // v2
+    if (!PPSSPP){
+      if (pspXploitFindFunction("GTARemastered", "GTARemasteredLib", 0x49346935) != 0){
+        if (pspXploitFindFunction("GTARemastered", "GTARemasteredLib", 0xF1396FCD) != 0){
+          GTA_REMASTERED = 1; // v1
+        }
+        else {
+          GTA_REMASTERED = 2; // v2
+        }
       }
     }
 

--- a/source/main.h
+++ b/source/main.h
@@ -242,5 +242,6 @@ void hex_marker_clear();
 #endif
 
 extern int LCS;
+extern int GTA_REMASTERED;
 
 #endif


### PR DESCRIPTION
Uses LibPspExploit for the functionality needed for the check.

NOTE: tested on real hardware only.

Library is available in latest pspsdk, but if using an older one (like I did), then you can grab it here:
https://github.com/PSP-Archive/LibPspExploit/releases/tag/v1.2